### PR TITLE
feat: configure renovate for automated dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency Dashboard",
+  "rebaseWhen": "conflicted",
+  "commitMessagePrefix": "chore(deps):",
+  "commitMessageAction": "update",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "to {{newVersion}}",
+  "semanticCommits": "enabled",
+  "timezone": "UTC",
+  "schedule": ["before 4am on monday"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "updateNotScheduled": false,
+  "minimumReleaseAge": "7 days",
+  "stabilityDays": 7,
+  "postUpdateOptions": ["npmDedupe"],
+  "packageRules": [
+    {
+      "description": "Disable patch updates to focus on meaningful changes",
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    },
+    {
+      "description": "Group TypeScript ecosystem updates",
+      "groupName": "TypeScript ecosystem",
+      "matchPackageNames": [
+        "typescript",
+        "@types/node",
+        "ts-node",
+        "ts-proto",
+        "@typescript-eslint/eslint-plugin",
+        "@typescript-eslint/parser",
+        "typescript-eslint"
+      ]
+    },
+    {
+      "description": "Group testing framework updates", 
+      "groupName": "Testing frameworks",
+      "matchPackageNames": [
+        "vitest",
+        "@vitest/coverage-v8",
+        "@vitest/ui",
+        "@vitest/eslint-plugin"
+      ]
+    },
+    {
+      "description": "Group gRPC related updates",
+      "groupName": "gRPC packages",
+      "matchPackageNames": [
+        "@grpc/grpc-js",
+        "@grpc/proto-loader",
+        "grpc-server-reflection"
+      ]
+    },
+    {
+      "description": "Group ESLint ecosystem updates",
+      "groupName": "ESLint ecosystem",
+      "matchPackageNames": [
+        "eslint",
+        "@eslint/js",
+        "eslint-plugin-*"
+      ],
+      "matchPackagePatterns": [
+        "^eslint-plugin-"
+      ]
+    },
+    {
+      "description": "Group build tools updates",
+      "groupName": "Build tools",
+      "matchPackageNames": [
+        "tsup",
+        "rollup",
+        "vite",
+        "vite-node"
+      ]
+    },
+    {
+      "description": "Automerge minor and patch updates with safety delay",
+      "matchUpdateTypes": ["minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "requiredStatusChecks": ["build", "test", "lint"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Major updates require manual review",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["dependencies", "major-update", "review-required"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": ["security", "vulnerability"]
+  },
+  "osvVulnerabilityAlerts": true,
+  "labels": ["dependencies", "renovate"],
+  "addLabels": ["automated-pr"],
+  "assigneesFromCodeOwners": true,
+  "reviewersFromCodeOwners": true,
+  "enabledManagers": ["npm"],
+  "includeForks": false,
+  "forkProcessing": "disabled",
+  "packageFiles": [
+    "package.json",
+    "apis/*/package.json",
+    "libs/*/package.json",
+    "services/*/package.json"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am on monday"]
+  }
+}


### PR DESCRIPTION
## Summary
Implements Issue #55 by configuring Renovate bot for automated dependency management across the monorepo packages.

## Changes
- ✅ Created `.github/renovate.json` configuration file
- ✅ Configured multi-package discovery for independent packages in `apis/`, `libs/`, and `services/`
- ✅ Set up dependency grouping to reduce PR noise (TypeScript, testing, gRPC, ESLint, build tools)
- ✅ Enabled automerge for minor updates with CI safety checks (`build`, `test`, `lint`)
- ✅ Configured 7-day minimum release age for stability
- ✅ Disabled patch updates to focus on meaningful changes
- ✅ Added vulnerability alerts and security monitoring

## Safety Features
- 🛡️ Requires CI status checks before automerge
- 🕐 7-day minimum release age for stability
- 📊 Rate limiting (5 concurrent PRs, 2 per hour)
- 🔒 Vulnerability alerts enabled
- 👥 Manual review required for major updates

## Dependencies
- Assumes CI workflows will be available (being implemented separately)
- Will discover and manage 5 packages: root + 2 APIs + 1 lib + 1 service

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)