### PR TITLE
docs: cleanup outdated migration references and inconsistencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,10 @@
 # CLAUDE.md
 
-## Core Behavior
-
-Be brutally honest, don't be a yes man. If I am wrong, point it out bluntly. I need honest feedback on my code. Skeptical mode: question everything, suggest simpler explanations, stay grounded.
-
 ## Issue Management Workflow
 
 1. **Check Existing Issues**
 
    - Search GitHub Issues for related work
-   - Check migration map in `/docs/issue-migration.md` for historical context
 
 2. **Create New Issues**
 
@@ -70,7 +65,7 @@ Be brutally honest, don't be a yes man. If I am wrong, point it out bluntly. I n
 
 - `lab preflight`: Run verification across all packages
 - `lab setup`: Install dependencies and setup environment
-- `lab publish <library>`: Publish library to local registry
+- `lab dev`: Run everything locally in dev mode
 
 ## Essential Rules
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -22,6 +22,7 @@ Create an issue ONLY if the improvement:
 ### Issue Templates
 
 The repository includes structured templates for:
+
 - **Development Tickets**: For features, bugs, and improvements
 - **RFCs**: For architectural decisions and major changes
 
@@ -37,4 +38,3 @@ The repository includes structured templates for:
 - Use the GitHub web interface or CLI for all issue operations
 - Follow the label conventions defined in CLAUDE.md
 - Issues are automatically closed when linked PRs are merged
-- For historical reference, see `/docs/issue-migration.md`


### PR DESCRIPTION
## Summary

- Remove Core Behavior section from CLAUDE.md  
- Remove references to non-existent issue-migration.md file from documentation
- Update lab command references from 'lab publish' to 'lab dev' across all documentation
- Fix markdown formatting in workflows.md 
- Ensure consistency between CLAUDE.md and .serena/memories/suggested_commands.md

## Test plan

- [x] All preflight checks pass
- [x] Documentation references are consistent
- [x] No functional code changes
- [x] Clean documentation maintenance

🤖 Generated with [Claude Code](https://claude.ai/code)